### PR TITLE
fix-can_not_trace_multi_service_name

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,9 +271,9 @@ func (conf Config) Log(kong *pdk.PDK) {
 		return
 	}
 	// (eventually) initialize tracer
-	if tracer == nil {
+	//if tracer == nil {
 		initTracer(conf, kong.Log)
-	}
+	//}
 	// get and parse log message
 	s, err := kong.Log.Serialize()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -270,10 +270,8 @@ func (conf Config) Log(kong *pdk.PDK) {
 	if !conf.Active() {
 		return
 	}
-	// (eventually) initialize tracer
-	//if tracer == nil {
-		initTracer(conf, kong.Log)
-	//}
+	// initialize tracer
+	initTracer(conf, kong.Log)
 	// get and parse log message
 	s, err := kong.Log.Serialize()
 	if err != nil {


### PR DESCRIPTION
when I want to add a multi-service name APM but the plugin can config only one 
I fix it by initrace always . It works